### PR TITLE
Terminal size: get stdout descriptor...

### DIFF
--- a/modules/tui/tui.go
+++ b/modules/tui/tui.go
@@ -39,7 +39,8 @@ func MainLoop() {
 }
 
 func initUI() {
-	width, height, _ := term.GetSize(0)
+	fd := int(os.Stdout.Fd())
+	width, height, _ := term.GetSize(fd)
 	frameWidth := width - 10
 	widgetWidth := frameWidth - 5
 


### PR DESCRIPTION
...instead on relying on 0.
Assuming 0 works only for unix-like OS. With this change the correct size of the term is e.g. recognized on Windows.
_______________
Something I noticed, when I looked into your use of clui :)
With this added and manually setting the config file, bookmarkscli will look like it should in Powershell, Terminal or CMD. Before it had zero size edit fields, as width and height were 0 and everywhere it was used had a negative value after the calculation.
The module os was already in use, therefore I assume the small change doesn't hurt, as it still works as it should on unix like OS.

Disclaimer: I'm fairly new to Go (like in complete beginner), so feel free to point out any issues :)