### PR TITLE
Track Go module data

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,17 @@
+module bookmarkscli
+
+go 1.19
+
+require (
+	github.com/jairochavesb/clui v1.2.1
+	github.com/mattn/go-sqlite3 v1.14.16
+	github.com/nsf/termbox-go v1.1.1
+	golang.org/x/term v0.1.0
+)
+
+require (
+	github.com/atotto/clipboard v0.1.4 // indirect
+	github.com/huandu/xstrings v1.3.2 // indirect
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	golang.org/x/sys v0.1.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,16 @@
+github.com/atotto/clipboard v0.1.4 h1:EH0zSVneZPSuFR11BlR9YppQTVDbh5+16AmcJi4g1z4=
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
+github.com/huandu/xstrings v1.3.2 h1:L18LIDzqlW6xN2rEkpdV8+oL/IXWJ1APd+vsdYy4Wdw=
+github.com/huandu/xstrings v1.3.2/go.mod h1:y5/lhBue+AyNmUVz9RLU9xbLR0o4KIIExikq4ovT0aE=
+github.com/jairochavesb/clui v1.2.1 h1:L1En/ttJ/xTyJ+DrpwT4zZOe60ZwHJkta+Jgs9owPAE=
+github.com/jairochavesb/clui v1.2.1/go.mod h1:L9e7AYog01HpPF7sM+GDPQ/3LomldqDt1IUfeV6hpPE=
+github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-sqlite3 v1.14.16 h1:yOQRA0RpS5PFz/oikGwBEqvAWhWg5ufRz4ETLjwpU1Y=
+github.com/mattn/go-sqlite3 v1.14.16/go.mod h1:2eHXhiwb8IkHr+BDWZGa96P6+rkvnG63S2DGjv9HUNg=
+github.com/nsf/termbox-go v1.1.1 h1:nksUPLCb73Q++DwbYUBEglYBRPZyoXJdrj5L+TkjyZY=
+github.com/nsf/termbox-go v1.1.1/go.mod h1:T0cTdVuOwf7pHQNtfhnEbzHbcNyCEcVU4YPpouCbVxo=
+golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
+golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/term v0.1.0 h1:g6Z6vPFA9dYBAF7DWcH6sCcOntplXsDKcliusYijMlw=
+golang.org/x/term v0.1.0/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=

--- a/main.go
+++ b/main.go
@@ -1,9 +1,9 @@
 package main
 
 import (
-	"bookmarksV2/modules/config"
-	"bookmarksV2/modules/db"
-	"bookmarksV2/modules/tui"
+	"bookmarkscli/modules/config"
+	"bookmarkscli/modules/db"
+	"bookmarkscli/modules/tui"
 	"os"
 )
 

--- a/modules/db/db.go
+++ b/modules/db/db.go
@@ -1,7 +1,7 @@
 package db
 
 import (
-	"bookmarksV2/modules/config"
+	"bookmarkscli/modules/config"
 	"database/sql"
 	"log"
 	"os"

--- a/modules/tui/tui.go
+++ b/modules/tui/tui.go
@@ -1,8 +1,8 @@
 package tui
 
 import (
-	"bookmarksV2/modules/config"
-	"bookmarksV2/modules/db"
+	"bookmarkscli/modules/config"
+	"bookmarkscli/modules/db"
 	"log"
 	"os"
 	"os/exec"


### PR DESCRIPTION
https://github.com/golang/go/wiki/Modules#should-i-commit-my-gosum-file-as-well-as-my-gomod-file
Which allows to simply run "go build" after cloning the repo.

Theoretically works with the latest versions, but go-runewidth not updated to 0.0.14. Calls in a new dep with a new indirect dep, which would need to stay at 0.2.0

Additionally adjust the import statement for the submodules, as without adjustments "go build" would fail because of not found packages in GOROOT
____________
Feel free to disregard this, but I stumpled upon the  missing go.mod and my understanding is, that this file is now the prefered way of declaring deps?